### PR TITLE
Add Jest-based asset checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "sschwandter.github.io",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^30.0.0"
+  }
+}

--- a/tests/assets.test.js
+++ b/tests/assets.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const htmlPath = path.join(__dirname, '..', 'index.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+
+const regex = /<(?:img|source)[^>]*src="([^"\s]+)"/gi;
+const assets = [];
+let match;
+while ((match = regex.exec(html)) !== null) {
+  assets.push(match[1]);
+}
+
+describe('Referenced assets exist', () => {
+  assets.forEach(asset => {
+    test(`File ${asset} should exist`, () => {
+      const assetPath = path.join(__dirname, '..', asset);
+      expect(fs.existsSync(assetPath)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an ignore for `node_modules`
- set up `package.json` with jest test runner
- write a jest test that verifies images and audio files referenced in `index.html` exist

## Testing
- `npm test` *(fails: `jest` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e201f4910832c8e5ab4110083af9f